### PR TITLE
Reuse MSBuild.exe exit code

### DIFF
--- a/frontend.bat
+++ b/frontend.bat
@@ -228,7 +228,7 @@ echo hMSBuild: !xMSBuild!
 call :dbgprint "Arguments: !args!"
 
 !xMSBuild! !args!
-exit /B 0
+exit /B %ERRORLEVEL%
 
 :: - - -
 :: Tools from VS2017+


### PR DESCRIPTION
This ensures a non-zero exit code is returned when MSBuild.exe fails.
Fixes #4