### PR TITLE
Visual Studio 2017 Update 3 compatibility

### DIFF
--- a/frontend.bat
+++ b/frontend.bat
@@ -320,7 +320,7 @@ if [!vsver!]==[] (
 )
 
 for /f "tokens=1,2 delims=." %%a in ("!vsver!") do (
-    set vsver=%%a.%%b
+    set vsver=%%a.0
 )
 set msbuildPath=!vspath!\MSBuild\!vsver!\Bin
 


### PR DESCRIPTION
MSBuild.exe v15.3 is located in the folder `<vspath>\MSBuild\15.0\Bin`, not `<vspath>\MSBuild\15.3\Bin` - so we have to hard code the "0" instead of using the minor version "3". 
It's a Microsoft decision, so there's not much else that can be done here to handle the situation.

Fixes #3 